### PR TITLE
Add support for SHA-1 in responses

### DIFF
--- a/idp.go
+++ b/idp.go
@@ -25,6 +25,8 @@ func (idp *IdentityProvider) NewSignedLoginResponse() (string, error) {
 	}
 	response := lib.NewResponse()
 	response.SetIdpCertificate(idp.x509IdpCertificate)
+	resposne.SetSignatureAlgorithm(idp.signatureAlgorithm())
+	resposne.SetDigestAlgorithm(idp.digestAlgorithm())
 	response.SetIssuer(idp.Issuer)
 	response.SetDestination(idp.ACSLocation)
 	response.SetNameId(idp.NameIdentifierFormat, idp.NameIdentifier)
@@ -58,6 +60,8 @@ func (idp *IdentityProvider) NewSignedLogoutResponse() (string, error) {
 	if idp.samlRequestParam != nil {
 		response.InResponseTo = idp.samlRequestParam.LogoutRequest.ID
 	}
+	resposne.SetSignatureAlgorithm(idp.signatureAlgorithm())
+	resposne.SetDigestAlgorithm(idp.digestAlgorithm())
 	signedXml, err := response.SignedXml(idp.idpPrivateKey)
 	if err != nil {
 		return "", err
@@ -303,6 +307,22 @@ func (idp *IdentityProvider) validate() error {
 		}
 	}
 	return nil
+}
+
+func (idp *IdentityProvider) signatureAlgorithm() string {
+	if idp.SignatureAlgorithm == "" {
+		return SignatureAlgorithmRSASHA256
+	}
+
+	return idp.SignatureAlgorithm
+}
+
+func (idp *IdentityProvider) digestAlgorithm() string {
+	if idp.DigestAlgorithm == "" {
+		return DigestAlgorithmSHA256
+	}
+
+	return idp.DigestAlgorithm
 }
 
 func prepareSamlRequestParam(method string, query url.Values, payload url.Values, requestType string) (*SamlRequestParam, error) {

--- a/internal/authnResponse.go
+++ b/internal/authnResponse.go
@@ -69,7 +69,8 @@ func NewResponse() *Response {
 						XMLName: xml.Name{
 							Local: "ds:SignatureMethod",
 						},
-						Algorithm: "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+
+						Algorithm: "", // populated by SetSignatureAlgorithm
 					},
 					SamlsigReference: SamlsigReference{
 						XMLName: xml.Name{
@@ -96,7 +97,7 @@ func NewResponse() *Response {
 							XMLName: xml.Name{
 								Local: "ds:DigestMethod",
 							},
-							Algorithm: "http://www.w3.org/2001/04/xmlenc#sha256",
+							Algorithm: "", // populated by SetDigestAlgorithm
 						},
 						DigestValue: DigestValue{
 							XMLName: xml.Name{
@@ -258,6 +259,14 @@ func (r *Response) SetSessionIndex(sessionIndex string) {
 func (r *Response) SetInResponseTo(inResponseTo string) {
 	r.InResponseTo = inResponseTo
 	r.Assertion.Subject.SubjectConfirmation.SubjectConfirmationData.InResponseTo = inResponseTo
+}
+
+func (r *Response) SetSignatureAlgorithm(alg string) {
+	r.Assertion.Signature.SignedInfo.SignatureMethod.Algorithm = alg
+}
+
+func (r *Response) SetDigestAlgorithm(alg string) {
+	r.Assertion.Signature.SignedInfo.SamlsigReference.DigestMethod.Algorithm = alg
 }
 
 func (r *Response) SignedXml(idpPrivateKey interface{}) (string, error) {

--- a/internal/logoutResponse.go
+++ b/internal/logoutResponse.go
@@ -58,7 +58,7 @@ func NewLogoutResponse() *LogoutResponse {
 					XMLName: xml.Name{
 						Local: "ds:SignatureMethod",
 					},
-					Algorithm: "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+					Algorithm: "", // populated by SetSignatureAlgorithm
 				},
 				SamlsigReference: SamlsigReference{
 					XMLName: xml.Name{
@@ -85,7 +85,7 @@ func NewLogoutResponse() *LogoutResponse {
 						XMLName: xml.Name{
 							Local: "ds:DigestMethod",
 						},
-						Algorithm: "http://www.w3.org/2001/04/xmlenc#sha256",
+						Algorithm: "", // populated by SetDigestAlgorithm
 					},
 					DigestValue: DigestValue{
 						XMLName: xml.Name{
@@ -140,6 +140,14 @@ func (r *LogoutResponse) String() (string, error) {
 
 func (r *LogoutResponse) SetInResponseTo(inResponseTo string) {
 	r.InResponseTo = inResponseTo
+}
+
+func (r *LogoutResponse) SetSignatureAlgorithm(alg string) {
+	r.Signature.SignedInfo.SignatureMethod.Algorithm = alg
+}
+
+func (r *LogoutResponse) SetDigestAlgorithm(alg string) {
+	r.Signature.SignedInfo.SamlsigReference.DigestMethod.Algorithm = alg
 }
 
 func (r *LogoutResponse) SignedXml(idpPrivateKey interface{}) (string, error) {

--- a/saml.go
+++ b/saml.go
@@ -15,6 +15,18 @@ const (
 	AttributeFormatUri         = "urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
 )
 
+// Supported signature algorithms for responses
+const (
+	SignatureAlgorithmRSASHA1   = "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
+	SignatureAlgorithmRSASHA256 = "http://www.w3.org/2001/04/xmldsig-more#sha256"
+)
+
+// Supported digest algorithms for responses
+const (
+	DigestAlgorithmSHA1   = "http://www.w3.org/2000/09/xmldsig#sha1"
+	DigestAlgorithmSHA256 = "http://www.w3.org/2001/04/xmlenc#sha256"
+)
+
 type IdentityProvider struct {
 	IsIdpInitiated       bool
 	Issuer               string
@@ -23,9 +35,9 @@ type IdentityProvider struct {
 	IDPKey               string
 	SPCert               string
 	Attributes           []map[string]string
-	SignatureAlgorithm   string
+	SignatureAlgorithm   string // RSA-SHA256 is the default
 	SignaturePrefix      string
-	DigestAlgorithm      string
+	DigestAlgorithm      string // SHA256 is the default
 	LifetimeInSeconds    int64
 	NameIdentifier       string
 	NameIdentifierFormat string


### PR DESCRIPTION
Use the SigningAlgorithm and DigestAlgorithm fields on IdentityProvider
to configure digest and signing algorithms for responses. If not set,
the default of SHA256 and RSA-SHA256 will be used.

closes #1 