### PR TITLE
Add Github Action with linter

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,32 @@
+name: Go
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: '^1.13'
+    - name: Checkout code
+      uses: actions/checkout@v1
+    - name: Environment information
+      run: |
+        go version
+        go env
+    - name: Vet
+      run: go vet -v ./...
+    - name: Lint
+      run: |
+        export PATH=$PATH:$(go env GOPATH)/bin
+        go get -u golang.org/x/lint/golint
+        golint -set_exit_status ./...
+    - name: staticcheck.io
+      run: |
+        export PATH=$PATH:$(go env GOPATH)/bin
+        go get honnef.co/go/tools/cmd/staticcheck
+        staticcheck -checks all ./...
+    - name: Test
+      run: go test -race -count=1 ./...


### PR DESCRIPTION
Runs [go vet](https://golang.org/cmd/vet/), [golint](https://github.com/golang/lint) and [staticcheck](https://staticcheck.io/) on the code.
Also runs go test (a no-op as there are not tests yet).

Currently the linting fails with warnings about missing comments on exported methods.
Good thing is there is aleady an issue (#4) to improve the comments :-)

An example of the output can be seen here: https://github.com/x-way/go-saml/actions/runs/285580397

Signed-off-by: Andreas Jaggi <andreas.jaggi@waterwave.ch>

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](../../../CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?


### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
